### PR TITLE
Add capability to skip force setting the java source and target compatibility to match the gradle minimum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ build
 
 .idea/
 .DS_Store
+
+# Ignore buildship created directories
+bin/
+*.project
+*.classpath
+.settings/

--- a/subprojects/gradle-plugin-development/src/main/java/dev/gradleplugins/GradlePluginDevelopmentCompatibilityExtension.java
+++ b/subprojects/gradle-plugin-development/src/main/java/dev/gradleplugins/GradlePluginDevelopmentCompatibilityExtension.java
@@ -13,4 +13,14 @@ public interface GradlePluginDevelopmentCompatibilityExtension {
      * @return a property to configure the minimum support Gradle version, never null.
      */
     Property<String> getMinimumGradleVersion();
+
+    /**
+     * Configures the compatibility system to skip setting the minimum java version.
+     *
+     * There are cases where a higher minimum Java version is allowed, such as internal plugins
+     * guaranteed to run on specific Java versions at minimum.
+     *
+     * @return a property to configure skipping minimum Java version, never null
+     */
+    Property<Boolean> getSkipMinimumJavaVersion();
 }

--- a/subprojects/gradle-plugin-development/src/main/java/dev/gradleplugins/internal/plugins/AbstractGradlePluginDevelopmentPlugin.java
+++ b/subprojects/gradle-plugin-development/src/main/java/dev/gradleplugins/internal/plugins/AbstractGradlePluginDevelopmentPlugin.java
@@ -112,7 +112,9 @@ public abstract class AbstractGradlePluginDevelopmentPlugin implements Plugin<Pr
     public static void configureExtension(GradlePluginDevelopmentCompatibilityExtension extension, Project project) {
         project.afterEvaluate(proj -> {
             if (extension.getMinimumGradleVersion().isPresent()) {
-                configureDefaultJavaCompatibility(project.getExtensions().getByType(JavaPluginExtension.class), VersionNumber.parse(extension.getMinimumGradleVersion().get()));
+                if (extension.getSkipMinimumJavaVersion().getOrElse(false)) {
+                    configureDefaultJavaCompatibility(project.getExtensions().getByType(JavaPluginExtension.class), VersionNumber.parse(extension.getMinimumGradleVersion().get()));
+                }
             } else {
                 extension.getMinimumGradleVersion().set(project.getGradle().getGradleVersion());
             }


### PR DESCRIPTION
There are cases where a plugin requires a newer Java version, and currently there is now way to do this. This plugin always will overwrite the source and target version unconditionally. This PR adds a flag to the compatiblity extension to allow skipping that requirement