### PR TITLE
Introduce coverage testing strategy for latest minor of each major

### DIFF
--- a/subprojects/gradle-plugin-development/src/main/java/dev/gradleplugins/GradlePluginTestingStrategyFactory.java
+++ b/subprojects/gradle-plugin-development/src/main/java/dev/gradleplugins/GradlePluginTestingStrategyFactory.java
@@ -1,5 +1,10 @@
 package dev.gradleplugins;
 
+import org.gradle.api.provider.Provider;
+import org.gradle.util.GradleVersion;
+
+import java.util.Set;
+
 public interface GradlePluginTestingStrategyFactory {
     /**
      * Returns a testing strategy which will cover the minimum Gradle version supported by the plugin.
@@ -18,10 +23,19 @@ public interface GradlePluginTestingStrategyFactory {
     GradleVersionCoverageTestingStrategy getCoverageForLatestNightlyVersion();
 
     /**
+     * Returns a testing strategy which will cover the latest Gradle released version of each major version above the minimum supported version.
+     * This strategy imply {@link #getCoverageForLatestGlobalAvailableVersion()}.
+     * This strategy may result in multiple {@link GradleVersionCoverageTestingStrategy}.
+     *
+     * @return a set of {@link GradlePluginTestingStrategy} instance for the latest Gradle GA version of each major version above minimum supported version, never null
+     */
+    Provider<Set<GradleVersionCoverageTestingStrategy>> getCoverageForLatestGlobalAvailableVersionOfEachMajorVersion();
+
+    /**
      * Returns a testing strategy which will cover the latest Gradle released version.
      * This strategy relies on https://services.gradle.org/versions/current data.
      *
-     * @return a {@link GradlePluginTestingStrategy} instance for the latest Gradle nightly version, never null
+     * @return a {@link GradlePluginTestingStrategy} instance for the latest Gradle GA version, never null
      */
     GradleVersionCoverageTestingStrategy getCoverageForLatestGlobalAvailableVersion();
 

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradlePluginTestingStrategyFactoryNoMinimumVersionTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradlePluginTestingStrategyFactoryNoMinimumVersionTest.java
@@ -1,0 +1,49 @@
+package dev.gradleplugins;
+
+import dev.gradleplugins.internal.GradlePluginTestingStrategyFactoryInternal;
+import dev.gradleplugins.internal.ReleasedVersionDistributions;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+
+import static dev.gradleplugins.GradleReleases.*;
+import static dev.gradleplugins.GradleVersionsTestService.builder;
+import static dev.gradleplugins.ProjectMatchers.absentProvider;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GradlePluginTestingStrategyFactoryNoMinimumVersionTest {
+    private final ProviderFactory providerFactory = ProjectBuilder.builder().build().getProviders();
+    private final GradlePluginTestingStrategyFactory subject = new GradlePluginTestingStrategyFactoryInternal(providerFactory.provider(() -> null), new ReleasedVersionDistributions(builder()
+            .version(globalAvailable("7.3"))
+            .version(snapshotFor("7.4"))
+            .version(releaseCandidateFor("7.4"))
+            .version(current(globalAvailable("7.4")))
+            .version(snapshotFor("7.5"))
+            .build()));
+
+    @Test
+    void throwsExceptionOnMinimumVersionQuery() {
+        assertThrows(IllegalStateException.class, () -> subject.getCoverageForMinimumVersion().getVersion());
+    }
+
+    @Test
+    void returnsAbsentProviderOnLatestGlobalAvailableVersionOfEachMajorVersion() {
+        assertThat(subject.getCoverageForLatestGlobalAvailableVersionOfEachMajorVersion(), absentProvider());
+    }
+
+    @Test
+    void doesNotThrowExceptionWhenLatestGlobalAvailableVersionQuery() {
+        assertDoesNotThrow(() -> subject.getCoverageForLatestGlobalAvailableVersion().getVersion());
+    }
+
+    @Test
+    void doesNotThrowExceptionWhenLatestNightlyVersionQuery() {
+        assertDoesNotThrow(() -> subject.getCoverageForLatestNightlyVersion().getVersion());
+    }
+
+    @Test
+    void doesNotThrowExceptionWhenGradleVersionQuery() {
+        assertDoesNotThrow(() -> subject.coverageForGradleVersion("7.3").getVersion());
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleReleases.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleReleases.java
@@ -1,0 +1,43 @@
+package dev.gradleplugins;
+
+import dev.gradleplugins.internal.ReleasedVersionDistributions;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+
+import static java.time.temporal.ChronoField.*;
+
+public final class GradleReleases {
+    private static final DateTimeFormatter SNAPSHOT_DATE_FORMATTER = new DateTimeFormatterBuilder()
+            .appendValue(YEAR, 4)
+            .appendValue(MONTH_OF_YEAR, 2)
+            .appendValue(DAY_OF_MONTH, 2)
+            .appendValue(HOUR_OF_DAY, 2)
+            .appendValue(MINUTE_OF_HOUR, 2)
+            .appendValue(SECOND_OF_MINUTE, 2)
+            .appendOffset("+HHMM", "-0000")
+            .toFormatter();
+    private static long rcCount = 0;
+
+    public static ReleasedVersionDistributions.GradleRelease snapshotFor(String version) {
+        assert !version.contains("-") : "'version' must be a GA version";
+        return new ReleasedVersionDistributions.GradleRelease(version + "-" + SNAPSHOT_DATE_FORMATTER.format(ZonedDateTime.now()), true, false, "");
+    }
+
+    public static ReleasedVersionDistributions.GradleRelease releaseCandidateFor(String version) {
+        assert !version.contains("-") : "'version' must be a GA version";
+        return new ReleasedVersionDistributions.GradleRelease(version + "-rc-" + ++rcCount, false, false, version);
+    }
+
+    public static ReleasedVersionDistributions.GradleRelease globalAvailable(String version) {
+        assert !version.contains("-") : "'version' must be a GA version";
+        return new ReleasedVersionDistributions.GradleRelease(version, false, false, "");
+    }
+
+    public static ReleasedVersionDistributions.GradleRelease current(ReleasedVersionDistributions.GradleRelease release) {
+        assert !release.isSnapshot();
+        assert !release.getVersion().contains("-rc-");
+        return new ReleasedVersionDistributions.GradleRelease(release.getVersion(), false, true, "");
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyEqualsTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyEqualsTest.java
@@ -1,0 +1,65 @@
+package dev.gradleplugins;
+
+import dev.gradleplugins.internal.GradlePluginTestingStrategyFactoryInternal;
+import dev.gradleplugins.internal.ReleasedVersionDistributions;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+
+import static dev.gradleplugins.GradleReleases.*;
+import static dev.gradleplugins.GradleVersionsTestService.builder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class GradleVersionCoverageTestingStrategyEqualsTest {
+    private final ProviderFactory providerFactory = ProjectBuilder.builder().build().getProviders();
+    private ReleasedVersionDistributions.GradleRelease latestSnapshot;
+    private ReleasedVersionDistributions.GradleRelease latestGlobalAvailable;
+    private final GradlePluginTestingStrategyFactory factory = new GradlePluginTestingStrategyFactoryInternal(providerFactory.provider(() -> "7.1"), new ReleasedVersionDistributions(builder()
+            .version(globalAvailable("7.1"))
+            .version(globalAvailable("7.2"))
+            .version(snapshotFor("7.3"))
+            .version(latestGlobalAvailable = current(globalAvailable("7.3")))
+            .version(latestSnapshot = snapshotFor("7.4"))
+            .build()));
+
+    @Test
+    void minimumVersionsAreEquals() {
+        assertEquals(factory.getCoverageForMinimumVersion(), factory.getCoverageForMinimumVersion());
+    }
+
+    @Test
+    void minimumVersionIsEqualToExactGradleVersion() {
+        assertEquals(factory.coverageForGradleVersion("7.1"), factory.getCoverageForMinimumVersion());
+    }
+
+    @Test
+    void minimumVersionIsNotEqualToLatestGlobalAvailableVersion() {
+        assertNotEquals(factory.getCoverageForLatestGlobalAvailableVersion(), factory.getCoverageForMinimumVersion());
+    }
+
+    @Test
+    void minimumVersionIsNotEqualToLatestNightlyVersion() {
+        assertNotEquals(factory.getCoverageForLatestNightlyVersion(), factory.getCoverageForMinimumVersion());
+    }
+
+    @Test
+    void latestNightlyAreEquals() {
+        assertEquals(factory.getCoverageForLatestNightlyVersion(), factory.getCoverageForLatestNightlyVersion());
+    }
+
+    @Test
+    void latestGlobalAvailableAreEquals() {
+        assertEquals(factory.getCoverageForLatestGlobalAvailableVersion(), factory.getCoverageForLatestGlobalAvailableVersion());
+    }
+
+    @Test
+    void latestGlobalAvailableIsEqualToExactGradleVersion() {
+        assertEquals(factory.coverageForGradleVersion(latestGlobalAvailable.getVersion()), factory.getCoverageForLatestGlobalAvailableVersion());
+    }
+
+    @Test
+    void latestNightlyIsEqualToExactGradleVersion() {
+        assertEquals(factory.coverageForGradleVersion(latestSnapshot.getVersion()), factory.getCoverageForLatestNightlyVersion());
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyGradleLatestSnapshotVersionTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyGradleLatestSnapshotVersionTest.java
@@ -1,0 +1,51 @@
+package dev.gradleplugins;
+
+import dev.gradleplugins.internal.GradlePluginTestingStrategyFactoryInternal;
+import dev.gradleplugins.internal.ReleasedVersionDistributions;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import static dev.gradleplugins.GradleReleases.*;
+import static dev.gradleplugins.GradleVersionsTestService.builder;
+import static dev.gradleplugins.ProjectMatchers.named;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GradleVersionCoverageTestingStrategyGradleLatestSnapshotVersionTest {
+    private final ProviderFactory providerFactory = ProjectBuilder.builder().build().getProviders();
+    private ReleasedVersionDistributions.GradleRelease latestSnapshot;
+    private final GradlePluginTestingStrategyFactory factory = new GradlePluginTestingStrategyFactoryInternal(providerFactory.provider(() -> "6.7"), new ReleasedVersionDistributions(builder()
+            .version(globalAvailable("6.7"))
+            .version(snapshotFor("6.8"))
+            .version(current(globalAvailable("6.8")))
+            .version(latestSnapshot = snapshotFor("6.9"))
+            .build()));
+    private final GradleVersionCoverageTestingStrategy subject = factory.coverageForGradleVersion(latestSnapshot.getVersion());
+
+    @Test
+    void isLatestNightly() {
+        assertTrue(subject.isLatestNightly());
+    }
+
+    @Test
+    void isNotLatestGlobalAvailable() {
+        assertFalse(subject.isLatestGlobalAvailable());
+    }
+
+    @Test
+    void hasVersion() {
+        assertEquals(latestSnapshot.getVersion(), subject.getVersion());
+    }
+
+    @Test
+    void usesVersionAsName() {
+        assertThat(subject, named(latestSnapshot.getVersion()));
+    }
+
+    @Test
+    void hasToString() {
+        assertThat(subject, Matchers.hasToString("coverage for Gradle v" + latestSnapshot.getVersion()));
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyGradleReleaseCandidateVersionTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyGradleReleaseCandidateVersionTest.java
@@ -1,0 +1,52 @@
+package dev.gradleplugins;
+
+import dev.gradleplugins.internal.GradlePluginTestingStrategyFactoryInternal;
+import dev.gradleplugins.internal.ReleasedVersionDistributions;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import static dev.gradleplugins.GradleReleases.*;
+import static dev.gradleplugins.GradleVersionsTestService.builder;
+import static dev.gradleplugins.ProjectMatchers.named;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class GradleVersionCoverageTestingStrategyGradleReleaseCandidateVersionTest {
+    private final ProviderFactory providerFactory = ProjectBuilder.builder().build().getProviders();
+    private ReleasedVersionDistributions.GradleRelease releaseCandidate;
+    private final GradlePluginTestingStrategyFactory factory = new GradlePluginTestingStrategyFactoryInternal(providerFactory.provider(() -> "6.7"), new ReleasedVersionDistributions(builder()
+            .version(globalAvailable("6.7"))
+            .version(releaseCandidate = releaseCandidateFor("6.8"))
+            .version(current(globalAvailable("6.8")))
+            .version(snapshotFor("6.9"))
+            .build()));
+    private final GradleVersionCoverageTestingStrategy subject = factory.coverageForGradleVersion(releaseCandidate.getVersion());
+
+    @Test
+    void isNotLatestNightly() {
+        assertFalse(subject.isLatestNightly());
+    }
+
+    @Test
+    void isNotLatestGlobalAvailable() {
+        assertFalse(subject.isLatestGlobalAvailable());
+    }
+
+    @Test
+    void hasVersion() {
+        assertEquals(releaseCandidate.getVersion(), subject.getVersion());
+    }
+
+    @Test
+    void usesVersionAsName() {
+        assertThat(subject, named(releaseCandidate.getVersion()));
+    }
+
+    @Test
+    void hasToString() {
+        assertThat(subject, Matchers.hasToString("coverage for Gradle v" + releaseCandidate.getVersion()));
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyGradleSnapshotVersionTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyGradleSnapshotVersionTest.java
@@ -1,0 +1,52 @@
+package dev.gradleplugins;
+
+import dev.gradleplugins.internal.GradlePluginTestingStrategyFactoryInternal;
+import dev.gradleplugins.internal.ReleasedVersionDistributions;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import static dev.gradleplugins.GradleReleases.*;
+import static dev.gradleplugins.GradleVersionsTestService.builder;
+import static dev.gradleplugins.ProjectMatchers.named;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class GradleVersionCoverageTestingStrategyGradleSnapshotVersionTest {
+    private final ProviderFactory providerFactory = ProjectBuilder.builder().build().getProviders();
+    private ReleasedVersionDistributions.GradleRelease snapshot;
+    private final GradlePluginTestingStrategyFactory factory = new GradlePluginTestingStrategyFactoryInternal(providerFactory.provider(() -> "6.7"), new ReleasedVersionDistributions(builder()
+            .version(globalAvailable("6.7"))
+            .version(snapshot = snapshotFor("6.8"))
+            .version(current(globalAvailable("6.8")))
+            .version(snapshotFor("6.9"))
+            .build()));
+    private final GradleVersionCoverageTestingStrategy subject = factory.coverageForGradleVersion(snapshot.getVersion());
+
+    @Test
+    void isNotLatestNightly() {
+        assertFalse(subject.isLatestNightly());
+    }
+
+    @Test
+    void isNotLatestGlobalAvailable() {
+        assertFalse(subject.isLatestGlobalAvailable());
+    }
+
+    @Test
+    void hasVersion() {
+        assertEquals(snapshot.getVersion(), subject.getVersion());
+    }
+
+    @Test
+    void usesVersionAsName() {
+        assertThat(subject, named(snapshot.getVersion()));
+    }
+
+    @Test
+    void hasToString() {
+        assertThat(subject, Matchers.hasToString("coverage for Gradle v" + snapshot.getVersion()));
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyGradleVersionTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyGradleVersionTest.java
@@ -1,0 +1,53 @@
+package dev.gradleplugins;
+
+import dev.gradleplugins.internal.GradlePluginTestingStrategyFactoryInternal;
+import dev.gradleplugins.internal.ReleasedVersionDistributions;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import static dev.gradleplugins.GradleReleases.current;
+import static dev.gradleplugins.GradleReleases.globalAvailable;
+import static dev.gradleplugins.GradleVersionsTestService.builder;
+import static dev.gradleplugins.ProjectMatchers.named;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GradleVersionCoverageTestingStrategyGradleVersionTest {
+    private final ProviderFactory providerFactory = ProjectBuilder.builder().build().getProviders();
+    private final GradlePluginTestingStrategyFactory factory = new GradlePluginTestingStrategyFactoryInternal(providerFactory.provider(() -> "6.7"), new ReleasedVersionDistributions(builder()
+            .version(globalAvailable("6.6"))
+            .version(globalAvailable("6.7"))
+            .version(globalAvailable("6.8"))
+            .version(globalAvailable("6.9"))
+            .version(globalAvailable("7.0"))
+            .version(current(globalAvailable("7.1")))
+            .build()));
+    private final GradleVersionCoverageTestingStrategy subject = factory.coverageForGradleVersion("6.8");
+
+    @Test
+    void isNotLatestNightly() {
+        assertFalse(subject.isLatestNightly());
+    }
+
+    @Test
+    void isNotLatestGlobalAvailable() {
+        assertFalse(subject.isLatestGlobalAvailable());
+    }
+
+    @Test
+    void hasVersion() {
+        assertEquals("6.8", subject.getVersion());
+    }
+
+    @Test
+    void usesVersionAsName() {
+        assertThat(subject, named("6.8"));
+    }
+
+    @Test
+    void hasToString() {
+        assertThat(subject, Matchers.hasToString("coverage for Gradle v6.8"));
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyLatestGlobalAvailableOfEachMajorVersionTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyLatestGlobalAvailableOfEachMajorVersionTest.java
@@ -1,0 +1,74 @@
+package dev.gradleplugins;
+
+import dev.gradleplugins.internal.GradlePluginTestingStrategyFactoryInternal;
+import dev.gradleplugins.internal.ReleasedVersionDistributions;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static dev.gradleplugins.GradleReleases.current;
+import static dev.gradleplugins.GradleReleases.globalAvailable;
+import static dev.gradleplugins.GradleVersionsTestService.builder;
+import static dev.gradleplugins.ProjectMatchers.named;
+import static dev.gradleplugins.ProjectMatchers.providerOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+class GradleVersionCoverageTestingStrategyLatestGlobalAvailableOfEachMajorVersionTest {
+    private final ProviderFactory providerFactory = ProjectBuilder.builder().build().getProviders();
+    private final GradlePluginTestingStrategyFactory factory = new GradlePluginTestingStrategyFactoryInternal(providerFactory.provider(() -> "5.6"), new ReleasedVersionDistributions(builder()
+            .version(globalAvailable("4.8"))
+            .version(globalAvailable("4.9"))
+            .version(globalAvailable("5.5"))
+            .version(globalAvailable("5.6"))
+            .version(globalAvailable("6.8"))
+            .version(globalAvailable("6.9"))
+            .version(globalAvailable("6.9.1"))
+            .version(globalAvailable("6.9.2"))
+            .version(globalAvailable("7.0"))
+            .version(globalAvailable("7.1"))
+            .version(current(globalAvailable("7.2")))
+            .build()));
+    private final Provider<Set<GradleVersionCoverageTestingStrategy>> subject = factory.getCoverageForLatestGlobalAvailableVersionOfEachMajorVersion();
+
+    @Test
+    void doesNotContainsLatestMinorOfMajorVersionPriorToMinimumVersion() {
+        assertThat(subject, providerOf(not(hasItem(factory.coverageForGradleVersion("4.9")))));
+    }
+
+    @Test
+    void hasLatestMinorOfEachMajorVersionsAfterMinimumVersionSortedByMajorVersions() {
+        assertThat(subject, providerOf(contains(factory.coverageForGradleVersion("5.6"), factory.coverageForGradleVersion("6.9.2"), factory.coverageForGradleVersion("7.2"))));
+    }
+
+    @Test
+    void includesLatestGlobalAvailable() {
+        assertThat(subject, providerOf(hasItem(latestGlobalAvailable())));
+    }
+
+    @Test
+    void usesVersionAsName() {
+        assertThat(subject, providerOf(contains(named("5.6"), named("6.9.2"), named("7.2"))));
+    }
+
+    private static Matcher<GradleVersionCoverageTestingStrategy> latestGlobalAvailable() {
+        return new TypeSafeMatcher<GradleVersionCoverageTestingStrategy>() {
+            @Override
+            protected boolean matchesSafely(GradleVersionCoverageTestingStrategy item) {
+                return item.isLatestGlobalAvailable();
+            }
+
+            @Override
+            public void describeTo(Description description) {
+
+            }
+        };
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyLatestGlobalAvailableVersionTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyLatestGlobalAvailableVersionTest.java
@@ -1,0 +1,53 @@
+package dev.gradleplugins;
+
+import dev.gradleplugins.internal.GradlePluginTestingStrategyFactoryInternal;
+import dev.gradleplugins.internal.ReleasedVersionDistributions;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import static dev.gradleplugins.GradleReleases.current;
+import static dev.gradleplugins.GradleReleases.globalAvailable;
+import static dev.gradleplugins.GradleVersionsTestService.builder;
+import static dev.gradleplugins.ProjectMatchers.named;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GradleVersionCoverageTestingStrategyLatestGlobalAvailableVersionTest {
+    private final ProviderFactory providerFactory = ProjectBuilder.builder().build().getProviders();
+    private ReleasedVersionDistributions.GradleRelease latestGlobalAvailable;
+    private final GradlePluginTestingStrategyFactory factory = new GradlePluginTestingStrategyFactoryInternal(providerFactory.provider(() -> "7.2"), new ReleasedVersionDistributions(builder()
+            .version(globalAvailable("6.9"))
+            .version(globalAvailable("7.0"))
+            .version(globalAvailable("7.1"))
+            .version(globalAvailable("7.2"))
+            .version(latestGlobalAvailable = current(globalAvailable("7.3")))
+            .build()));
+    private final GradleVersionCoverageTestingStrategy subject = factory.getCoverageForLatestGlobalAvailableVersion();
+
+    @Test
+    void isNotLatestNightly() {
+        assertFalse(subject.isLatestNightly());
+    }
+
+    @Test
+    void isLatestGlobalAvailable() {
+        assertTrue(subject.isLatestGlobalAvailable());
+    }
+
+    @Test
+    void hasVersion() {
+        assertEquals(latestGlobalAvailable.getVersion(), subject.getVersion());
+    }
+
+    @Test
+    void usesConceptAsName() {
+        assertThat(subject, named("latestGlobalAvailable"));
+    }
+
+    @Test
+    void hasToString() {
+        assertThat(subject, Matchers.hasToString("coverage for Gradle v" + latestGlobalAvailable.getVersion()));
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyLatestNightlyVersionTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyLatestNightlyVersionTest.java
@@ -1,0 +1,56 @@
+package dev.gradleplugins;
+
+import dev.gradleplugins.internal.GradlePluginTestingStrategyFactoryInternal;
+import dev.gradleplugins.internal.ReleasedVersionDistributions;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.gradle.util.GradleVersion;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import static dev.gradleplugins.GradleReleases.*;
+import static dev.gradleplugins.GradleVersionsTestService.builder;
+import static dev.gradleplugins.ProjectMatchers.named;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GradleVersionCoverageTestingStrategyLatestNightlyVersionTest {
+    private final ProviderFactory providerFactory = ProjectBuilder.builder().build().getProviders();
+    private ReleasedVersionDistributions.GradleRelease latestSnapshot;
+    private final GradlePluginTestingStrategyFactory factory = new GradlePluginTestingStrategyFactoryInternal(providerFactory.provider(() -> "6.3"), new ReleasedVersionDistributions(builder()
+            .version(snapshotFor("6.2"))
+            .version(globalAvailable("6.2"))
+            .version(snapshotFor("6.3"))
+            .version(globalAvailable("6.3"))
+            .version(snapshotFor("6.4"))
+            .version(releaseCandidateFor("6.4"))
+            .version(current(globalAvailable("6.4")))
+            .version(latestSnapshot = snapshotFor("6.5"))
+            .build()));
+    private final GradleVersionCoverageTestingStrategy subject = factory.getCoverageForLatestNightlyVersion();
+
+    @Test
+    void isLatestNightly() {
+        assertTrue(subject.isLatestNightly());
+    }
+
+    @Test
+    void isNotLatestGlobalAvailable() {
+        assertFalse(subject.isLatestGlobalAvailable());
+    }
+
+    @Test
+    void hasVersion() {
+        assertEquals(latestSnapshot.getVersion(), subject.getVersion());
+    }
+
+    @Test
+    void usesConceptAsName() {
+        assertThat(subject, named("latestNightly"));
+    }
+
+    @Test
+    void hasToString() {
+        assertThat(subject, Matchers.hasToString("coverage for Gradle v" + latestSnapshot.getVersion()));
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyMinimumVersionAsLatestGlobalAvailableVersionTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyMinimumVersionAsLatestGlobalAvailableVersionTest.java
@@ -1,0 +1,33 @@
+package dev.gradleplugins;
+
+import dev.gradleplugins.internal.GradlePluginTestingStrategyFactoryInternal;
+import dev.gradleplugins.internal.ReleasedVersionDistributions;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+
+import static dev.gradleplugins.GradleReleases.current;
+import static dev.gradleplugins.GradleReleases.globalAvailable;
+import static dev.gradleplugins.GradleVersionsTestService.builder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GradleVersionCoverageTestingStrategyMinimumVersionAsLatestGlobalAvailableVersionTest {
+    private final ProviderFactory providerFactory = ProjectBuilder.builder().build().getProviders();
+    private ReleasedVersionDistributions.GradleRelease latestGlobalAvailable;
+    private final GradlePluginTestingStrategyFactory factory = new GradlePluginTestingStrategyFactoryInternal(providerFactory.provider(() -> latestGlobalAvailable.getVersion()), new ReleasedVersionDistributions(builder()
+            .version(globalAvailable("6.0"))
+            .version(globalAvailable("6.1"))
+            .version(latestGlobalAvailable = current(globalAvailable("6.2")))
+            .build()));
+
+    @Test
+    void isLatestGlobalAvailable() {
+        assertTrue(factory.getCoverageForMinimumVersion().isLatestGlobalAvailable());
+    }
+
+    @Test
+    void equalsToLatestGlobalAvailableVersion() {
+        assertEquals(factory.getCoverageForLatestGlobalAvailableVersion(), factory.getCoverageForMinimumVersion());
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyMinimumVersionAsLatestNightlyVersionTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyMinimumVersionAsLatestNightlyVersionTest.java
@@ -1,0 +1,37 @@
+package dev.gradleplugins;
+
+import dev.gradleplugins.internal.GradlePluginTestingStrategyFactoryInternal;
+import dev.gradleplugins.internal.ReleasedVersionDistributions;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+
+import static dev.gradleplugins.GradleReleases.*;
+import static dev.gradleplugins.GradleVersionsTestService.builder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GradleVersionCoverageTestingStrategyMinimumVersionAsLatestNightlyVersionTest {
+    private final ProviderFactory providerFactory = ProjectBuilder.builder().build().getProviders();
+    private ReleasedVersionDistributions.GradleRelease latestSnapshot;
+    private final GradlePluginTestingStrategyFactory factory = new GradlePluginTestingStrategyFactoryInternal(providerFactory.provider(() -> latestSnapshot.getVersion()), new ReleasedVersionDistributions(builder()
+            .version(globalAvailable("7.0"))
+            .version(globalAvailable("7.1"))
+            .version(snapshotFor("7.2"))
+            .version(snapshotFor("7.2"))
+            .version(releaseCandidateFor("7.2"))
+            .version(releaseCandidateFor("7.2"))
+            .version(current(globalAvailable("7.2")))
+            .version(latestSnapshot = snapshotFor("7.3"))
+            .build()));
+
+    @Test
+    void isLatestNightly() {
+        assertTrue(factory.getCoverageForMinimumVersion().isLatestNightly());
+    }
+
+    @Test
+    void equalsToLatestNightlyVersion() {
+        assertEquals(factory.getCoverageForLatestNightlyVersion(), factory.getCoverageForMinimumVersion());
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyMinimumVersionTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyMinimumVersionTest.java
@@ -1,0 +1,50 @@
+package dev.gradleplugins;
+
+import dev.gradleplugins.internal.GradlePluginTestingStrategyFactoryInternal;
+import dev.gradleplugins.internal.ReleasedVersionDistributions;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import static dev.gradleplugins.GradleReleases.current;
+import static dev.gradleplugins.GradleReleases.globalAvailable;
+import static dev.gradleplugins.GradleVersionsTestService.builder;
+import static dev.gradleplugins.ProjectMatchers.named;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class GradleVersionCoverageTestingStrategyMinimumVersionTest {
+    private final ProviderFactory providerFactory = ProjectBuilder.builder().build().getProviders();
+    private final GradlePluginTestingStrategyFactory factory = new GradlePluginTestingStrategyFactoryInternal(providerFactory.provider(() -> "5.4"), new ReleasedVersionDistributions(builder()
+            .version(globalAvailable("5.4"))
+            .version(globalAvailable("5.5"))
+            .version(current(globalAvailable("5.6")))
+            .build()));
+    private final GradleVersionCoverageTestingStrategy subject = factory.getCoverageForMinimumVersion();
+
+    @Test
+    void isNotLatestNightly() {
+        assertFalse(subject.isLatestNightly());
+    }
+
+    @Test
+    void isNotLatestGlobalAvailable() {
+        assertFalse(subject.isLatestGlobalAvailable());
+    }
+
+    @Test
+    void hasMinimumVersion() {
+        assertEquals("5.4", subject.getVersion());
+    }
+
+    @Test
+    void usesConceptAsName() {
+        assertThat(subject, named("minimumGradle"));
+    }
+
+    @Test
+    void hasToString() {
+        assertThat(subject, Matchers.hasToString("coverage for Gradle v5.4"));
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyUnknownVersionTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionCoverageTestingStrategyUnknownVersionTest.java
@@ -1,0 +1,57 @@
+package dev.gradleplugins;
+
+import dev.gradleplugins.internal.GradlePluginTestingStrategyFactoryInternal;
+import dev.gradleplugins.internal.ReleasedVersionDistributions;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+
+import static dev.gradleplugins.GradleReleases.*;
+import static dev.gradleplugins.GradleVersionsTestService.builder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GradleVersionCoverageTestingStrategyUnknownVersionTest {
+    private final ProviderFactory providerFactory = ProjectBuilder.builder().build().getProviders();
+    private final GradlePluginTestingStrategyFactory factory = new GradlePluginTestingStrategyFactoryInternal(providerFactory.provider(() -> "2.5"), new ReleasedVersionDistributions(builder()
+            .version(globalAvailable("3.0"))
+            .version(snapshotFor("3.1"))
+            .version(snapshotFor("3.1"))
+            .version(releaseCandidateFor("3.1"))
+            .version(globalAvailable("3.1"))
+            .version(snapshotFor("3.2"))
+            .version(releaseCandidateFor("3.2"))
+            .version(current(globalAvailable("3.2")))
+            .version(snapshotFor("3.3"))
+            .build()));
+
+    @Test
+    void throwsExceptionWhenCoverageVersionIsUnknownGlobalAvailable() {
+        final Throwable ex = assertThrows(IllegalArgumentException.class, () -> factory.coverageForGradleVersion("5.4"));
+        assertEquals("Unknown Gradle version '5.4' for adhoc testing strategy.", ex.getMessage());
+    }
+
+    @Test
+    void throwsExceptionWhenCoverageVersionIsUnknownReleaseCandidate() {
+        final Throwable ex = assertThrows(IllegalArgumentException.class, () -> factory.coverageForGradleVersion("5.6-rc-1"));
+        assertEquals("Unknown Gradle version '5.6-rc-1' for adhoc testing strategy.", ex.getMessage());
+    }
+
+    @Test
+    void throwsExceptionWhenCoverageVersionIsUnknownSnapshot() {
+        final Throwable ex = assertThrows(IllegalArgumentException.class, () -> factory.coverageForGradleVersion("3.2-20220109234542-0000"));
+        assertEquals("Unknown Gradle version '3.2-20220109234542-0000' for adhoc testing strategy.", ex.getMessage());
+    }
+
+    @Test
+    void throwsExceptionWhenMinimumVersionIsUnknown() {
+        final Throwable ex = assertThrows(IllegalArgumentException.class, () -> factory.getCoverageForMinimumVersion().getVersion());
+        assertEquals("Unknown minimum Gradle version '2.5' for testing strategy.", ex.getMessage());
+    }
+
+    @Test
+    void throwsExceptionWhenCoverageForLatestMinorOfEachMajorWithUnknownMinimumVersion() {
+        final Throwable ex = assertThrows(IllegalArgumentException.class, () -> factory.getCoverageForLatestGlobalAvailableVersionOfEachMajorVersion().get());
+        assertEquals("Unknown minimum Gradle version '2.5' for testing strategy.", ex.getMessage());
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionsTestService.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradleVersionsTestService.java
@@ -1,0 +1,57 @@
+package dev.gradleplugins;
+
+import com.google.gson.Gson;
+import dev.gradleplugins.internal.GradleVersionsService;
+import dev.gradleplugins.internal.ReleasedVersionDistributions;
+import org.gradle.util.GradleVersion;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public final class GradleVersionsTestService implements GradleVersionsService {
+    private final List<ReleasedVersionDistributions.GradleRelease> releases;
+
+    private GradleVersionsTestService(List<ReleasedVersionDistributions.GradleRelease> releases) {
+        assert releases.stream().filter(ReleasedVersionDistributions.GradleRelease::isCurrent).count() <= 1;
+        this.releases = releases;
+    }
+
+    @Override
+    public InputStream nightly() throws IOException {
+        ReleasedVersionDistributions.GradleRelease result = releases.stream().filter(ReleasedVersionDistributions.GradleRelease::isSnapshot).max(Comparator.comparing(it -> GradleVersion.version(it.getVersion()))).orElseThrow(RuntimeException::new);
+        return new ByteArrayInputStream(new Gson().toJson(result).getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public InputStream current() throws IOException {
+        ReleasedVersionDistributions.GradleRelease result = releases.stream().filter(ReleasedVersionDistributions.GradleRelease::isCurrent).findFirst().orElseThrow(RuntimeException::new);
+        return new ByteArrayInputStream(new Gson().toJson(result).getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public InputStream all() throws IOException {
+        return new ByteArrayInputStream(new Gson().toJson(releases).getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private final List<ReleasedVersionDistributions.GradleRelease> releases = new ArrayList<>();
+
+        public Builder version(ReleasedVersionDistributions.GradleRelease release) {
+            releases.add(release);
+            return this;
+        }
+
+        public GradleVersionsTestService build() {
+            return new GradleVersionsTestService(releases);
+        }
+    }
+}


### PR DESCRIPTION
When a plugin span multiple major versions, testing against the latest
minor version or each supported major a great coverage metric. It's
not be trivial to implement such coverage strategy. We also improved the
testing around coverage strategies.