### PR TITLE
Introduce specification to match testing strategy regardless of their composition

### DIFF
--- a/subprojects/gradle-plugin-development/src/main/java/dev/gradleplugins/GradlePluginTestingStrategy.java
+++ b/subprojects/gradle-plugin-development/src/main/java/dev/gradleplugins/GradlePluginTestingStrategy.java
@@ -5,6 +5,10 @@ import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.testing.Test;
 
+import javax.annotation.Nullable;
+import java.util.Objects;
+import java.util.function.Predicate;
+
 /**
  * A testing strategy for a Gradle plugin project test suite.
  *
@@ -21,5 +25,67 @@ public interface GradlePluginTestingStrategy extends Named {
     @SuppressWarnings("unchecked")
     static Provider<GradlePluginTestingStrategy> testingStrategy(Test task) throws UnknownDomainObjectException {
         return (Provider<GradlePluginTestingStrategy>) task.getExtensions().getByName("testingStrategy");
+    }
+
+    /**
+     * Represents specification for {@link GradlePluginTestingStrategy}.
+     * The specification will walk through each element of a composite testing strategy as well as itself when testing the satisfaction.
+     *
+     * @param <T> testing strategy type
+     */
+    abstract class Spec<T extends GradlePluginTestingStrategy> {
+        public abstract boolean isSatisfiedBy(@Nullable T t);
+
+        /**
+         * This method simply acts a friendly reminder not to extends Spec directly and instead uses {@link #matches(Predicate)} factory method.
+         * It's easy to ignore JavaDoc, but a bit harder to ignore compile errors .
+         *
+         * @deprecated to make
+         */
+        @Deprecated
+        abstract void _do_not_extend_Spec___instead_uses_matches_factory_method();
+
+        /**
+         * Returns a specification that intersect between this spec and the specified spec.
+         *
+         * @param spec  a intersect spec, must not be null
+         * @return a intersect specification, never null
+         */
+        public Spec<T> and(Spec<? super T> spec) {
+            Objects.requireNonNull(spec);
+            return GradlePluginTestingStrategySpecs.and(this, spec);
+        }
+
+        /**
+         * Returns a specification that union between this spec and the specified spec.
+         *
+         * @param spec  a union spec, must not be null
+         * @return a union specification, never null
+         */
+        public Spec<T> or(Spec<? super T> spec) {
+            Objects.requireNonNull(spec);
+            return GradlePluginTestingStrategySpecs.or(this, spec);
+        }
+
+        /**
+         * Returns a specification that negate this spec.
+         *
+         * @return a negation specification, never null
+         */
+        public Spec<T> negate() {
+            return GradlePluginTestingStrategySpecs.not(this);
+        }
+
+        /**
+         * Returns a specification that try to match any testing strategy with the specified predicate.
+         *
+         * @param predicate  a predicate to match any testing strategy, must not be null
+         * @param <T>  testing strategy type to satisfy
+         * @return a specification that matches any testing strategy with the specified predicate, never null
+         */
+        public static <T extends GradlePluginTestingStrategy> Spec<T> matches(Predicate<? super T> predicate) {
+            Objects.requireNonNull(predicate);
+            return GradlePluginTestingStrategySpecs.matches(predicate);
+        }
     }
 }

--- a/subprojects/gradle-plugin-development/src/main/java/dev/gradleplugins/GradlePluginTestingStrategyFactory.java
+++ b/subprojects/gradle-plugin-development/src/main/java/dev/gradleplugins/GradlePluginTestingStrategyFactory.java
@@ -1,7 +1,6 @@
 package dev.gradleplugins;
 
 import org.gradle.api.provider.Provider;
-import org.gradle.util.GradleVersion;
 
 import java.util.Set;
 

--- a/subprojects/gradle-plugin-development/src/main/java/dev/gradleplugins/GradlePluginTestingStrategySpecs.java
+++ b/subprojects/gradle-plugin-development/src/main/java/dev/gradleplugins/GradlePluginTestingStrategySpecs.java
@@ -1,0 +1,99 @@
+package dev.gradleplugins;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+final class GradlePluginTestingStrategySpecs {
+    private GradlePluginTestingStrategySpecs() {}
+
+    public static <T extends GradlePluginTestingStrategy> GradlePluginTestingStrategy.Spec<T> and(GradlePluginTestingStrategy.Spec<T> left, GradlePluginTestingStrategy.Spec<? super T> right) {
+        return new AndSpec<>(left, right);
+    }
+
+    private static final class AndSpec<T extends GradlePluginTestingStrategy> extends GradlePluginTestingStrategy.Spec<T> {
+        private final GradlePluginTestingStrategy.Spec<T> left;
+        private final GradlePluginTestingStrategy.Spec<? super T> right;
+
+        public AndSpec(GradlePluginTestingStrategy.Spec<T> left, GradlePluginTestingStrategy.Spec<? super T> right) {
+            this.left = left;
+            this.right = right;
+        }
+
+        @Override
+        public boolean isSatisfiedBy(T t) {
+            return left.isSatisfiedBy(t) && right.isSatisfiedBy(t);
+        }
+
+        @Override
+        void _do_not_extend_Spec___instead_uses_matches_factory_method() {}
+    }
+
+    public static <T extends GradlePluginTestingStrategy> GradlePluginTestingStrategy.Spec<T> or(GradlePluginTestingStrategy.Spec<T> left, GradlePluginTestingStrategy.Spec<? super T> right) {
+        return new OrSpec<>(left, right);
+    }
+
+    private static final class OrSpec<T extends GradlePluginTestingStrategy> extends GradlePluginTestingStrategy.Spec<T> {
+        private final GradlePluginTestingStrategy.Spec<T> left;
+        private final GradlePluginTestingStrategy.Spec<? super T> right;
+
+        public OrSpec(GradlePluginTestingStrategy.Spec<T> left, GradlePluginTestingStrategy.Spec<? super T> right) {
+            this.left = left;
+            this.right = right;
+        }
+
+        @Override
+        public boolean isSatisfiedBy(T t) {
+            return left.isSatisfiedBy(t) || right.isSatisfiedBy(t);
+        }
+
+        @Override
+        void _do_not_extend_Spec___instead_uses_matches_factory_method() {}
+    }
+
+    public static <T extends GradlePluginTestingStrategy> GradlePluginTestingStrategy.Spec<T> not(GradlePluginTestingStrategy.Spec<T> self) {
+        return new NotSpec<>(self);
+    }
+
+    private static final class NotSpec<T extends GradlePluginTestingStrategy> extends GradlePluginTestingStrategy.Spec<T> {
+        private final GradlePluginTestingStrategy.Spec<T> delegate;
+
+        public NotSpec(GradlePluginTestingStrategy.Spec<T> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean isSatisfiedBy(T t) {
+            return !delegate.isSatisfiedBy(t);
+        }
+
+        @Override
+        void _do_not_extend_Spec___instead_uses_matches_factory_method() {}
+    }
+
+    public static <T extends GradlePluginTestingStrategy> GradlePluginTestingStrategy.Spec<T> matches(Predicate<? super T> predicate) {
+        return new MatchesSpec<>(predicate);
+    }
+
+    private static final class MatchesSpec<T extends GradlePluginTestingStrategy> extends GradlePluginTestingStrategy.Spec<T> {
+        private final Predicate<? super T> predicate;
+
+        public MatchesSpec(Predicate<? super T> predicate) {
+            this.predicate = predicate;
+        }
+
+        @Override
+        public boolean isSatisfiedBy(@Nullable T t) {
+            if (t instanceof CompositeGradlePluginTestingStrategy) {
+                return Stream.concat(Stream.of(t), StreamSupport.stream(((CompositeGradlePluginTestingStrategy) t).spliterator(), false)).anyMatch(it -> predicate.test((T) it));
+            } else {
+                return predicate.test(t);
+            }
+        }
+
+        @Override
+        void _do_not_extend_Spec___instead_uses_matches_factory_method() {}
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradlePluginTestingStrategySpecCompositeIntersectTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradlePluginTestingStrategySpecCompositeIntersectTest.java
@@ -1,0 +1,24 @@
+package dev.gradleplugins;
+
+import org.junit.jupiter.api.Test;
+
+import static dev.gradleplugins.GradlePluginTestingStrategy.Spec.matches;
+import static dev.gradleplugins.GradlePluginTestingStrategyTestUtils.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GradlePluginTestingStrategySpecCompositeIntersectTest {
+    private final GradlePluginTestingStrategy.Spec<GradlePluginTestingStrategy> subject = matches(aStrategy()::equals).and(matches(anotherStrategy("here")::equals));
+
+    @Test
+    void isNotSatisfiedByPartialMatchingStrategy() {
+        assertFalse(subject.isSatisfiedBy(aStrategy()));
+        assertFalse(subject.isSatisfiedBy(anotherStrategy("here")));
+    }
+
+    @Test
+    void isSatisfiedByCompositeStrategyWithAllStrategiesRegardlessOfOrder() {
+        assertTrue(subject.isSatisfiedBy(aCompositeStrategy(aStrategy(), anotherStrategy("here"))));
+        assertTrue(subject.isSatisfiedBy(aCompositeStrategy(anotherStrategy("here"), aStrategy())));
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradlePluginTestingStrategySpecCompositeTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradlePluginTestingStrategySpecCompositeTest.java
@@ -1,0 +1,23 @@
+package dev.gradleplugins;
+
+import org.junit.jupiter.api.Test;
+
+import static dev.gradleplugins.GradlePluginTestingStrategy.Spec.matches;
+import static dev.gradleplugins.GradlePluginTestingStrategyTestUtils.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GradlePluginTestingStrategySpecCompositeTest {
+    private final GradlePluginTestingStrategy.Spec<GradlePluginTestingStrategy> subject = matches(aCompositeStrategy(aStrategy(), anotherStrategy("kloe"))::equals);
+
+    @Test
+    void isSatisfiedByExactMatchingCompositeStrategy() {
+        assertTrue(subject.isSatisfiedBy(aCompositeStrategy(aStrategy(), anotherStrategy("kloe"))));
+    }
+
+    @Test
+    void isNotSatisfiedByIndividualStrategyOfComposition() {
+        assertFalse(subject.isSatisfiedBy(aStrategy()));
+        assertFalse(subject.isSatisfiedBy(anotherStrategy("kloe")));
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradlePluginTestingStrategySpecCompositeUnionTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradlePluginTestingStrategySpecCompositeUnionTest.java
@@ -1,0 +1,36 @@
+package dev.gradleplugins;
+
+import org.junit.jupiter.api.Test;
+
+import static dev.gradleplugins.GradlePluginTestingStrategy.Spec.matches;
+import static dev.gradleplugins.GradlePluginTestingStrategyTestUtils.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GradlePluginTestingStrategySpecCompositeUnionTest {
+    private final GradlePluginTestingStrategy.Spec<GradlePluginTestingStrategy> subject = matches(aStrategy()::equals).or(matches(anotherStrategy("desy")::equals));
+
+    @Test
+    void isSatisfiedByAnyIndividualStrategyOfComposition() {
+        assertTrue(subject.isSatisfiedBy(aStrategy()));
+        assertTrue(subject.isSatisfiedBy(anotherStrategy("desy")));
+    }
+
+    @Test
+    void isSatisfiedByCompositionOfAnyIndividualStrategy() {
+        assertTrue(subject.isSatisfiedBy(aCompositeStrategy(aStrategy(), anotherStrategy("pole"))));
+        assertTrue(subject.isSatisfiedBy(aCompositeStrategy(anotherStrategy("desy"), anotherStrategy("pole"))));
+    }
+
+    @Test
+    void isSatisfiedByCompositionOfAllIndividualStrategy() {
+        assertTrue(subject.isSatisfiedBy(aCompositeStrategy(aStrategy(), anotherStrategy("desy"))));
+        assertTrue(subject.isSatisfiedBy(aCompositeStrategy(anotherStrategy("desy"), aStrategy())));
+    }
+
+    @Test
+    void isNotSatisfiedByUnrelatedStrategy() {
+        assertFalse(subject.isSatisfiedBy(aCompositeStrategy(anotherStrategy("lodk"), anotherStrategy("ertd"))));
+        assertFalse(subject.isSatisfiedBy(anotherStrategy("lope")));
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradlePluginTestingStrategySpecNegationTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradlePluginTestingStrategySpecNegationTest.java
@@ -1,0 +1,29 @@
+package dev.gradleplugins;
+
+import org.junit.jupiter.api.Test;
+
+import static dev.gradleplugins.GradlePluginTestingStrategy.Spec.matches;
+import static dev.gradleplugins.GradlePluginTestingStrategyTestUtils.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GradlePluginTestingStrategySpecNegationTest {
+    private final GradlePluginTestingStrategy.Spec<GradlePluginTestingStrategy> subject = matches(aStrategy()::equals).negate();
+
+    @Test
+    void isNotSatisfiedByExactMatchingStrategy() {
+        assertFalse(subject.isSatisfiedBy(aStrategy()));
+    }
+
+    @Test
+    void isNotSatisfiedByCompositionOfExactMatchingStrategy() {
+        assertFalse(subject.isSatisfiedBy(aCompositeStrategy(aStrategy(), anotherStrategy("kels"))));
+    }
+
+    @Test
+    void isSatisfiedByAnyOtherStrategy() {
+        assertTrue(subject.isSatisfiedBy(anotherStrategy()));
+        assertTrue(subject.isSatisfiedBy(anotherStrategy("dela")));
+        assertTrue(subject.isSatisfiedBy(aCompositeStrategy(anotherStrategy("eodf"), anotherStrategy("eloe"))));
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradlePluginTestingStrategySpecNullTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradlePluginTestingStrategySpecNullTest.java
@@ -1,0 +1,29 @@
+package dev.gradleplugins;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Predicate;
+
+import static dev.gradleplugins.GradlePluginTestingStrategy.Spec.matches;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GradlePluginTestingStrategySpecNullTest {
+    @Test
+    void throwsExceptionWhenPredicateIsNull() {
+        assertThrows(NullPointerException.class, () -> matches(null));
+    }
+
+    @Test
+    void throwsExceptionWhenOrSpecIsNull() {
+        assertThrows(NullPointerException.class, () -> matches(alwaysTrue()).or(null));
+    }
+
+    @Test
+    void throwsExceptionWhenAndSpecIsNull() {
+        assertThrows(NullPointerException.class, () -> matches(alwaysTrue()).and(null));
+    }
+
+    private static <T> Predicate<T> alwaysTrue() {
+        return t -> true;
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradlePluginTestingStrategySpecTest.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradlePluginTestingStrategySpecTest.java
@@ -1,0 +1,32 @@
+package dev.gradleplugins;
+
+import org.junit.jupiter.api.Test;
+
+import static dev.gradleplugins.GradlePluginTestingStrategy.Spec.matches;
+import static dev.gradleplugins.GradlePluginTestingStrategyTestUtils.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GradlePluginTestingStrategySpecTest {
+    private final GradlePluginTestingStrategy.Spec<GradlePluginTestingStrategy> subject = matches(aStrategy()::equals);
+
+    @Test
+    void isSatisfiedByExactMatchingStrategy() {
+        assertTrue(subject.isSatisfiedBy(aStrategy()));
+    }
+
+    @Test
+    void isNotSatisfiedByAnotherStrategyThanMatchingStrategy() {
+        assertFalse(subject.isSatisfiedBy(anotherStrategy()));
+    }
+
+    @Test
+    void isSatisfiedByCompositeStrategyContainingMatchingStrategy() {
+        assertTrue(subject.isSatisfiedBy(aCompositeStrategy(anotherStrategy(), aStrategy())));
+    }
+
+    @Test
+    void isNotSatisfiedByCompositeStrategyNotContainingMatchingStrategy() {
+        assertFalse(subject.isSatisfiedBy(aCompositeStrategy(anotherStrategy(), anotherStrategy("dkel"))));
+    }
+}

--- a/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradlePluginTestingStrategyTestUtils.java
+++ b/subprojects/gradle-plugin-development/src/test/groovy/dev/gradleplugins/GradlePluginTestingStrategyTestUtils.java
@@ -1,8 +1,14 @@
 package dev.gradleplugins;
 
+import org.apache.commons.lang3.StringUtils;
+
 import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Iterator;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public final class GradlePluginTestingStrategyTestUtils {
     private GradlePluginTestingStrategyTestUtils() {}
@@ -58,10 +64,12 @@ public final class GradlePluginTestingStrategyTestUtils {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o)
+            if (this == o) {
                 return true;
-            if (!(o instanceof AnotherStrategy))
+            }
+            if (!(o instanceof AnotherStrategy)) {
                 return false;
+            }
             AnotherStrategy that = (AnotherStrategy) o;
             return Objects.equals(what, that.what);
         }
@@ -74,6 +82,50 @@ public final class GradlePluginTestingStrategyTestUtils {
         @Override
         public String toString() {
             return "anotherStrategy(" + (what == null ? "" : what.toString()) + ")";
+        }
+    }
+
+    public static GradlePluginTestingStrategy aCompositeStrategy(GradlePluginTestingStrategy... strategies) {
+        return new ACompositeStrategy(Arrays.asList(strategies));
+    }
+
+    private static final class ACompositeStrategy implements CompositeGradlePluginTestingStrategy {
+        private final Iterable<GradlePluginTestingStrategy> strategies;
+
+        private ACompositeStrategy(Iterable<GradlePluginTestingStrategy> strategies) {
+            this.strategies = strategies;
+        }
+
+        @Override
+        public String getName() {
+            return StringUtils.uncapitalize(StreamSupport.stream(strategies.spliterator(), false).map(GradlePluginTestingStrategy::getName).map(StringUtils::capitalize).collect(Collectors.joining()));
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ACompositeStrategy)) {
+                return false;
+            }
+            ACompositeStrategy that = (ACompositeStrategy) o;
+            return Objects.equals(strategies, that.strategies);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(strategies);
+        }
+
+        @Override
+        public String toString() {
+            return "aCompositeStrategy(" + strategies + ")";
+        }
+
+        @Override
+        public Iterator<GradlePluginTestingStrategy> iterator() {
+            return strategies.iterator();
         }
     }
 }


### PR DESCRIPTION
We introduce a Gradle Spec-like API specifically to match testing strategies. We can't use a simple Predicate as we want to catch logical errors as soon as possible. It would be too easy to do something like `matches(<predicate>).and(<predicate>)` which would only be true if both `<predicate>` matches the same thing. With a custom spec, which we deny custom implementation, the previous would be an error. Instead, users will have to use `matches(<predicate>).and(matches(<predicate>))` which both predicates can match different testing strategies and the final spec will only return true if both predicates end up matching two testing strategies regardless of there composition. Both testing strategies could be the same but don't necessarily need to be the same. If users want to intersect a predicate on the same testing predicate then it would have to use something like: `matches(<predicate>.and(<predicate>))`. Note the `and` operating is executed on the predicate, not on the spec.

Fixes https://github.com/gradle-plugins/toolbox/issues/72